### PR TITLE
Removed the deprecated "Mastering Markdown" link

### DIFF
--- a/content/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/about-writing-and-formatting-on-github.md
+++ b/content/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/about-writing-and-formatting-on-github.md
@@ -42,4 +42,3 @@ You can enable a fixed-width font in every comment field on {% data variables.pr
 - [{% data variables.product.prodname_dotcom %} Flavored Markdown Spec](https://github.github.com/gfm/)
 - "[Basic writing and formatting syntax](/articles/basic-writing-and-formatting-syntax)"
 - "[Working with advanced formatting](/articles/working-with-advanced-formatting)"
-- "[Mastering Markdown](https://guides.github.com/features/mastering-markdown/)"


### PR DESCRIPTION
As per #20424

```markdown
- "[Mastering Markdown](https://guides.github.com/features/mastering-markdown/)"
```